### PR TITLE
Adding a way to bypass catching of exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1178,6 +1178,17 @@ You can create a mutation by extending `AbstractObjectType` or by creating a new
 It is crucial for the class to have a `getType` method returning the actual OutputType of your mutation but it couldn't be implemented as abstract method, so we created a wrapper class called `AbstractMutationObjectType`.
 This abstract class can help you to not forget about `OutputType` by forcing you to implement a method `getOutputType` that will eventually be used by internal `getType` method.
 
+### Error handling
+
+By default, the library will catch any exception and bundle the exception message in the JSON message returned.
+It can be convenient to disable this feature (particularly while developing) in order to have a full stack trace displayed.
+
+To disable, error handling, you need to modify the execution context:
+
+```php
+$processor->getExecutionContext()->setCatchExceptions(false);
+```
+
 ## Useful information
 
 This section will be updating on a regular basis with the useful links and references that might help you to quicker become a better GraphQL developer.

--- a/src/Execution/Processor.php
+++ b/src/Execution/Processor.php
@@ -59,11 +59,13 @@ class Processor
     /** @var array DeferredResult[] */
     protected $deferredResults = [];
 
-    public function __construct(AbstractSchema $schema)
+    public function __construct(AbstractSchema $schema, ExecutionContext $executionContext = null)
     {
-        if (empty($this->executionContext)) {
+        if ($executionContext === null) {
             $this->executionContext = new ExecutionContext($schema);
             $this->executionContext->setContainer(new Container());
+        } else {
+            $this->executionContext = $executionContext;
         }
 
         $this->resolveValidator = new ResolveValidator($this->executionContext);

--- a/src/Validator/ErrorContainer/ErrorContainerTrait.php
+++ b/src/Validator/ErrorContainer/ErrorContainerTrait.php
@@ -17,8 +17,14 @@ trait ErrorContainerTrait
     /** @var \Exception[] */
     protected $errors = [];
 
+    /** @var bool */
+    protected $catchExceptions  = true;
+
     public function addError(\Exception $exception)
     {
+        if (!$this->catchExceptions && !$exception instanceof DatableExceptionInterface && !$exception instanceof LocationableExceptionInterface) {
+            throw $exception;
+        }
         $this->errors[] = $exception;
 
         return $this;
@@ -32,6 +38,11 @@ trait ErrorContainerTrait
     public function getErrors()
     {
         return $this->errors;
+    }
+
+    public function setCatchExceptions($catchExceptions)
+    {
+        $this->catchExceptions = $catchExceptions;
     }
 
     public function mergeErrors(ErrorContainerInterface $errorContainer)


### PR DESCRIPTION
Hey guys!

First of all, thank you for your great work on bringing GraphQL to PHP :)

I'm facing an issue regarding exception handling and I believe I'm not the only one here.

When an exception or error is thrown in one of the resolvers, the exception is catched and the error message is displayed in the JSON output (in the errors key). The problem is that only the error message is outputed, but we loose the stack trace.

For instance, today, I faced the error:

> Undefined index "id".

Without a file or line number, it is almost impossible to debug.

I believe #137 and #146 are trying to solve the same problem.

In this proposal, I simply propose to add a flag to completely disable exception catching. This way, when an exception arises, it is propagated to the output and can be catched by any middleware down the stream (like Whoops). This is absolutely great when developing.

```php
$processor->getExecutionContext()->setCatchExceptions(false);
```

Let me know if you think this approach can be interesting.