### PR TITLE
Change Node::fromGlobalId() to be stricter about validating input

### DIFF
--- a/Tests/Library/Relay/NodeTest.php
+++ b/Tests/Library/Relay/NodeTest.php
@@ -9,6 +9,7 @@
 namespace Youshido\Tests\Library\Relay;
 
 
+use InvalidArgumentException;
 use Youshido\GraphQL\Relay\Node;
 
 class NodeTest extends \PHPUnit_Framework_TestCase
@@ -20,6 +21,23 @@ class NodeTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('user', $fromGlobal[0]);
         $this->assertEquals(1, $fromGlobal[1]);
-        $this->assertEquals([null, null], Node::fromGlobalId(null));
+    }
+
+    public function malformedIdProvider()
+    {
+        return [
+            [''],
+            [base64_encode('I have no colon')],
+            [null],
+        ];
+    }
+
+    /**
+     * @dataProvider malformedIdProvider
+     */
+    public function testFromGlobalIdThrowsExceptionIfGivenMalformedId($idToCheck)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+        Node::fromGlobalId($idToCheck);
     }
 }

--- a/src/Relay/Node.php
+++ b/src/Relay/Node.php
@@ -23,7 +23,7 @@ class Node
             throw new \InvalidArgumentException('ID must be a valid base 64 string');
         }
         $decodedParts = explode(':', $decoded, 2);
-        if (count($decodedParts) != 2) {
+        if (count($decodedParts) !== 2) {
             throw new \InvalidArgumentException('ID was not correctly formed');
         }
         return $decodedParts;

--- a/src/Relay/Node.php
+++ b/src/Relay/Node.php
@@ -18,11 +18,15 @@ class Node
      */
     public static function fromGlobalId($id)
     {
-        if ($decoded = base64_decode($id)) {
-            return explode(':', $decoded);
+        $decoded = base64_decode($id, true);
+        if (!$decoded) {
+            throw new \InvalidArgumentException('ID must be a valid base 64 string');
         }
-
-        return [null, null];
+        $decodedParts = explode(':', $decoded, 2);
+        if (count($decodedParts) != 2) {
+            throw new \InvalidArgumentException('ID was not correctly formed');
+        }
+        return $decodedParts;
     }
 
     /**


### PR DESCRIPTION
This pull request is to make Node::fromGlobalId() not break when the input id is not in the format that was expected.

This now throws an `InvalidArgumentException` if the input is invalid instead of `[null, null]` as the calling code would be unlikely to recover from it, but happy to change this back if desired.