### PR TITLE
 Run examples, small corrections

### DIFF
--- a/examples/01_sandbox/index.php
+++ b/examples/01_sandbox/index.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Sandbox;
 
 use Youshido\GraphQL\Execution\Processor;
@@ -6,7 +7,11 @@ use Youshido\GraphQL\Schema\Schema;
 use Youshido\GraphQL\Type\Object\ObjectType;
 use Youshido\GraphQL\Type\Scalar\StringType;
 
-require_once __DIR__ . '/../../../../../vendor/autoload.php';
+if(file_exists(__DIR__ . '/../../../../../vendor/autoload.php')) {
+    require_once __DIR__ . '/../../../../../vendor/autoload.php';
+} else {
+    require_once realpath(__DIR__ . '/../..') . '/vendor/autoload.php';
+}
 
 $processor = new Processor(new Schema([
     'query' => new ObjectType([

--- a/examples/02_blog/Schema/PostType.php
+++ b/examples/02_blog/Schema/PostType.php
@@ -13,6 +13,10 @@ use Youshido\GraphQL\Type\Scalar\StringType;
 
 class PostType extends AbstractObjectType
 {
+    /**
+     * @param \Youshido\GraphQL\Config\Object\ObjectTypeConfig $config
+     * @throws \Youshido\GraphQL\Exception\ConfigurationException
+     */
     public function build($config)
     {
         $config
@@ -28,7 +32,13 @@ class PostType extends AbstractObjectType
                     return (!empty($args['truncated'])) ? explode(' ', $value)[0] . '...' : $value;
                 }
             ])
-            ->addField('title', new NonNullType(new StringType()))
+            ->addField(
+                'title', [
+                    'type'  => new NonNullType(new StringType()),
+                    'args'  => [
+                        'truncated' => new BooleanType()
+                    ],
+                ])
             ->addField('status', new PostStatus())
             ->addField('summary', new StringType())
             ->addField('likeCount', new IntType());

--- a/examples/02_blog/index.php
+++ b/examples/02_blog/index.php
@@ -11,10 +11,10 @@ require_once __DIR__ . '/schema-bootstrap.php';
 $schema = new BlogSchema();
 
 $processor = new Processor($schema);
-$payload = 'mutation { likePost(id:5) { title(truncated: false), status, likeCount } }';
-$payload = '{ latestPost { title, status, likeCount } }';
-$payload = '{ pageContentUnion { ... on Post { title, summary } ... on Banner { title, imageLink } } }';
-$payload = '{ pageContentInterface { title} }';
+// $payload = 'mutation { likePost(id:5) { title(truncated: false), status, likeCount } }';
+// $payload = '{ latestPost { title, status, likeCount } }';
+// $payload = '{ pageContentUnion { ... on Post { title, summary } ... on Banner { title, imageLink } } }';
+// $payload = '{ pageContentInterface { title} }';
 $payload = 'mutation { createPost(author: "Alex", post: {title: "Hey, this is my new post", summary: "my post" }) { title } }';
 
 $processor->processPayload($payload);

--- a/examples/02_blog/schema-bootstrap.php
+++ b/examples/02_blog/schema-bootstrap.php
@@ -2,7 +2,12 @@
 
 namespace BlogTest;
 
-require_once __DIR__ . '/../../../../../vendor/autoload.php';
+if(file_exists(__DIR__ . '/../../../../../vendor/autoload.php')) {
+    require_once __DIR__ . '/../../../../../vendor/autoload.php';
+} else {
+    require_once realpath(__DIR__ . '/../..') . '/vendor/autoload.php';
+}
+
 require_once __DIR__ . '/Schema/DataProvider.php';
 require_once __DIR__ . '/Schema/PostType.php';
 require_once __DIR__ . '/Schema/PostStatus.php';

--- a/examples/02_blog_inline/index.php
+++ b/examples/02_blog_inline/index.php
@@ -6,8 +6,12 @@ use Youshido\GraphQL\Execution\Processor;
 use Youshido\GraphQL\Schema\Schema;
 use Youshido\GraphQL\Type\Object\ObjectType;
 
+if(file_exists(__DIR__ . '/../../../../../vendor/autoload.php')) {
+    require_once __DIR__ . '/../../../../../vendor/autoload.php';
+} else {
+    require_once realpath(__DIR__ . '/../..') . '/vendor/autoload.php';
+}
 
-require_once __DIR__ . '/../../../../../vendor/autoload.php';
 require_once __DIR__ . '/inline-schema.php';
 /** @var ObjectType $rootQueryType */
 

--- a/examples/02_blog_inline/inline-schema.php
+++ b/examples/02_blog_inline/inline-schema.php
@@ -26,7 +26,7 @@ $rootQueryType = new ObjectType([
                         ],
                         'resolve'           => function ($value, $args) {
                             // used argument to modify a field value
-                            return (!empty($args['truncated'])) ? explode(' ', $value)[0] . '...' : $value;
+                            return (!empty($args['truncated'])) ? explode(' ', $value['title'])[0] . '...' : $value['title'];
                         }
                     ],
                     // if field just has a type, you can use a short declaration syntax like this


### PR DESCRIPTION
* If no autoload found in parent, use local autoload
* Example 2, explode() expects parameter 2 to be string, array given, fixed
* Example 2, Unknown argument "truncated" on field "title", fixed
