### PR TITLE
Add more robust implementation for TypeService::getPropertyValue()

### DIFF
--- a/Tests/Issues/Issue210/TypeServiceTest.php
+++ b/Tests/Issues/Issue210/TypeServiceTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Youshido\Tests\Issues\Issue210;
+
+use PHPUnit\Framework\TestCase;
+use Youshido\GraphQL\Type\TypeService;
+
+class TypeServiceTest extends TestCase
+{
+
+    public function testGetPropertyValue()
+    {
+        $object = new DummyObjectWithTrickyGetters();
+
+        $this->assertEquals('Foo', TypeService::getPropertyValue($object, 'issuer'));
+        $this->assertEquals('something', TypeService::getPropertyValue($object, 'something'));
+        $this->assertEquals('Bar', TypeService::getPropertyValue($object, 'issuerName'));
+    }
+}
+
+class DummyObjectWithTrickyGetters
+{
+    public function getIssuer()
+    {
+        return 'Foo';
+    }
+
+    public function something()
+    {
+        return 'something';
+    }
+
+    public function issuerName()
+    {
+        return 'Bar';
+    }
+}

--- a/Tests/Issues/Issue98/TypeServiceTest.php
+++ b/Tests/Issues/Issue98/TypeServiceTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Youshido\Tests\Issues\Issue98;
+
+use PHPUnit\Framework\TestCase;
+use Youshido\GraphQL\Type\TypeService;
+
+class TypeServiceTest extends TestCase
+{
+    public function testPropertGetValueWithMagicGet()
+    {
+        $object = new DummyObjectWithMagicGet();
+
+        $this->assertEquals('getfoo', TypeService::getPropertyValue($object, 'foo'));
+        $this->assertEquals('getbar', TypeService::getPropertyValue($object, 'anything'));
+    }
+
+    public function testPropertyGetValueWithMagicCall()
+    {
+        $object = new DummyObjectWithMagicCall();
+
+        // __call() should not be considered by default
+        $this->assertNull(TypeService::getPropertyValue($object, 'foo'));
+        $this->assertNull(TypeService::getPropertyValue($object, 'anything'));
+
+        //$this->assertEquals('callfoo', TypeService::getPropertyValue($object, 'foo'));
+        //$this->assertEquals('callbar', TypeService::getPropertyValue($object, 'anything'));
+    }
+}
+
+class DummyObjectWithMagicGet
+{
+    public function __get($name)
+    {
+        if ($name === 'foo') {
+            return 'getfoo';
+        }
+
+        return 'getbar';
+    }
+
+}
+
+class DummyObjectWithMagicCall
+{
+    public function __call($name, $arguments)
+    {
+        if ($name === 'foo') {
+            return 'callfoo';
+        }
+
+        return 'callbar';
+    }
+}
+

--- a/Tests/Library/Type/UnionTypeTest.php
+++ b/Tests/Library/Type/UnionTypeTest.php
@@ -5,8 +5,7 @@
  * @author Portey Vasil <portey@gmail.com>
  */
 
-namespace Youshido\tests\Library\Type;
-
+namespace Youshido\Tests\Library\Type;
 
 use Youshido\GraphQL\Type\Object\ObjectType;
 use Youshido\GraphQL\Type\Scalar\IntType;

--- a/Tests/Library/Utilities/TypeUtilitiesTest.php
+++ b/Tests/Library/Utilities/TypeUtilitiesTest.php
@@ -14,7 +14,6 @@ use Youshido\GraphQL\Type\TypeMap;
 use Youshido\GraphQL\Type\TypeService;
 use Youshido\Tests\DataProvider\TestInterfaceType;
 use Youshido\Tests\DataProvider\TestObjectType;
-use Youshido\Tests\Library\Type\ObjectTypeTest;
 
 class TypeUtilitiesTest extends \PHPUnit_Framework_TestCase
 {
@@ -60,7 +59,44 @@ class TypeUtilitiesTest extends \PHPUnit_Framework_TestCase
     public function testGetPropertyValue() {
         $arrayData = (new TestObjectType())->getData();
 
+        // Test with arrays
         $this->assertEquals('John', TypeService::getPropertyValue($arrayData, 'name'));
         $this->assertEquals('John', TypeService::getPropertyValue((object) $arrayData, 'name'));
+
+        // Test with objects with getters
+        $object = new ObjectWithVariousGetters();
+
+        $this->assertEquals('John', TypeService::getPropertyValue($object, 'name'));
+        $this->assertEquals('John Doe', TypeService::getPropertyValue($object, 'namedAfter'));
+        $this->assertTrue(TypeService::getPropertyValue($object, 'true'));
+        $this->assertFalse(TypeService::getPropertyValue($object, 'false'));
+        $this->assertNull(TypeService::getPropertyValue($arrayData, 'doesntExist'));
+        $this->assertNull(TypeService::getPropertyValue($object, 'doesntExist'));
+    }
+}
+
+/**
+ * Dummy class for testing getPropertyValue()
+ */
+class ObjectWithVariousGetters
+{
+    public function getName()
+    {
+        return 'John';
+    }
+
+    public function getNamedAfter()
+    {
+        return 'John Doe';
+    }
+
+    public function isTrue()
+    {
+        return true;
+    }
+
+    public function isFalse()
+    {
+        return false;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
     }
   },
   "autoload-dev": {
-    "classmap": [
-      "Tests/"
-    ]
+    "psr-4": {
+      "Youshido\\Tests\\": "Tests"
+    }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
   ],
   "require": {
     "php": ">=5.5,<8.0-DEV",
-    "ext-mbstring": "*"
+    "ext-mbstring": "*",
+    "symfony/property-access": "^2.8"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8"

--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,10 @@
     "psr-4": {
       "Youshido\\Tests\\": "Tests"
     }
+  },
+  "config": {
+    "platform": {
+      "php": "5.5"
+    }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     }
   ],
   "require": {
-    "php": ">=5.5,<8.0-DEV"
+    "php": ">=5.5,<8.0-DEV",
+    "ext-mbstring": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8"

--- a/src/Type/TypeService.php
+++ b/src/Type/TypeService.php
@@ -125,14 +125,28 @@ class TypeService
         return $type instanceof AbstractInputObjectType;
     }
 
-    public static function getPropertyValue($data, $path)
+    /**
+     * @param object|array $data
+     * @param string       $path
+     * @param bool         $enableMagicCall whether to attempt to resolve properties using __call()
+     *
+     * @return mixed|null
+     */
+    public static function getPropertyValue($data, $path, $enableMagicCall = false)
     {
         // Normalize the path
         if (is_array($data)) {
             $path = "[$path]";
         }
 
-        $propertyAccessor = PropertyAccess::createPropertyAccessor();
+        // Optionally enable __call() support
+        $propertyAccessorBuilder = PropertyAccess::createPropertyAccessorBuilder();
+
+        if ($enableMagicCall) {
+            $propertyAccessorBuilder->enableMagicCall();
+        }
+
+        $propertyAccessor = $propertyAccessorBuilder->getPropertyAccessor();
 
         return $propertyAccessor->isReadable($data, $path) ? $propertyAccessor->getValue($data, $path) : null;
     }


### PR DESCRIPTION
Fixes #210, also incidentally fixes #203, closes #98 

I added some test cases against the initial implementation first, then some broken test cases, then switched to using `symfony/property-accessor` and all the tests started passing. A net gain in my opinion.

A third parameter `$enableMagicCall` has been added to `getPropertyValue()` to allow resolving properties from objects implementing `__call()` for getters. It's an optional feature of `symfony/property-accessor` and can be quite obscure if implicitly enabled, so I added a flag for it.